### PR TITLE
Migrate to Godot 4

### DIFF
--- a/addons/KOBUGE-games.CircularContainer/CircularContainer.gd
+++ b/addons/KOBUGE-games.CircularContainer/CircularContainer.gd
@@ -1,33 +1,33 @@
-tool
+@tool
 extends Container
 
 ## Properties ##
-var _force_squares = false setget _private_set, _private_get
-var _force_expand = false setget _private_set, _private_get
-var _start_angle = 0 setget _private_set, _private_get
-var _percent_visible = 1 setget _private_set, _private_get
-var _appear_at_once = false setget _private_set, _private_get
-var _allow_node2d = false setget _private_set, _private_get
-var _start_empty = false setget _private_set, _private_get
-var _custom_animator_func = null setget _private_set, _private_get
+var _force_squares = false
+var _force_expand = false
+var _start_angle = 0
+var _percent_visible = 1
+var _appear_at_once = false
+var _allow_node2d = false
+var _start_empty = false
+var _custom_animator: Callable = Callable()
 
 ## Cached variables ##
-var _cached_min_size_key = "" setget _private_set, _private_get
-var _cached_min_size = null setget _private_set, _private_get
-var _cached_min_size_dirty = false setget _private_set, _private_get
+var _cached_min_size_key = ""
+var _cached_min_size = null
+var _cached_min_size_dirty = false
 
 ## Callbacks ##
 
 func _ready():
-	connect("sort_children", self, "_resort")
+	connect("sort_children", Callable(self, "_resort"))
 	_resort()
 
 ## Properties / Public API ##
 
 func set_custom_animator(object, method): # Params of animator function : node (Control or Node2D), center_pos, target_pos, time (0..1)
-	_custom_animator_func = funcref(object, method)
+	_custom_animator = Callable(object, method)
 func unset_custom_animator():
-	_custom_animator_func = null
+	_custom_animator = Callable()
 
 func set_force_squares(enable):
 	_force_squares = bool(enable)
@@ -51,11 +51,11 @@ func get_start_angle():
 	return _start_angle
 
 func set_start_angle_deg(angle):
-	_start_angle = deg2rad(float(angle))
+	_start_angle = deg_to_rad(float(angle))
 	_resort()
 
 func get_start_angle_deg():
-	return rad2deg(_start_angle)
+	return rad_to_deg(_start_angle)
 
 func set_percent_visible(percent):
 	_percent_visible = clamp(float(percent), 0, 1)
@@ -96,14 +96,14 @@ func _get_property_list():
 		{usage = PROPERTY_USAGE_CATEGORY, type = TYPE_NIL, name = "CircularContainer"},
 		{type = TYPE_BOOL, name = "arrange/force_squares"},
 		{type = TYPE_BOOL, name = "arrange/force_expand"},
-		{type = TYPE_REAL, name = "arrange/start_angle", hint = PROPERTY_HINT_RANGE, hint_string = "-1080,1080,0.01"},
+		{type = TYPE_FLOAT, name = "arrange/start_angle", hint = PROPERTY_HINT_RANGE, hint_string = "-1080,1080,0.01"},
 		{type = TYPE_BOOL, name = "arrange/start_empty"},
 		{type = TYPE_BOOL, name = "arrange/allow_node2d"},
-		{type = TYPE_REAL, name = "animate/percent_visible", hint = PROPERTY_HINT_RANGE, hint_string = "0,1,0.01"},
+		{type = TYPE_FLOAT, name = "animate/percent_visible", hint = PROPERTY_HINT_RANGE, hint_string = "0,1,0.01"},
 		{type = TYPE_BOOL, name = "animate/all_at_once"}
 	]
 
-func _set(property, value):
+func _set(property, value) -> bool:
 	if property == "arrange/force_squares": set_force_squares(value)
 	if property == "arrange/force_expand": set_force_expand(value)
 	elif property == "arrange/start_angle": set_start_angle_deg(value)
@@ -119,7 +119,7 @@ func _set(property, value):
 func _get(property):
 	if property == "arrange/force_squares": return _force_squares
 	if property == "arrange/force_expand": return _force_expand
-	elif property == "arrange/start_angle": return rad2deg(_start_angle)
+	elif property == "arrange/start_angle": return rad_to_deg(_start_angle)
 	elif property == "arrange/start_empty": return _start_empty
 	elif property == "arrange/allow_node2d": return _allow_node2d
 	elif property == "animate/percent_visible": return _percent_visible
@@ -184,8 +184,8 @@ func _put_child_at_angle(child, radius, origin, angle_start, angle_size, appear)
 	if child is Control:
 		child.set_size(size)
 	
-	if _custom_animator_func != null:
-		_custom_animator_func.call_func(child, origin, target, appear)
+	if not _custom_animator.is_null():
+		_custom_animator.call(child, origin, target, appear)
 	else:
 		_default_animator(child, origin, target, appear)
 
@@ -240,9 +240,9 @@ func _update_cached_min_size():
 
 func _default_animator(node, container_center, target_pos, time):
 	if node is Control:
-		node.set_position(container_center.linear_interpolate(target_pos - node.get_size() / 2 * time, time))
+		node.set_position(container_center.lerp(target_pos - node.get_size() / 2 * time, time))
 	else:
-		node.set_position(container_center.linear_interpolate(target_pos, time))
+		node.set_position(container_center.lerp(target_pos, time))
 	#node.set_opacity(time)
 	if time == 0:
 		node.set_scale(Vector2(0.01,0.01))

--- a/addons/KOBUGE-games.CircularContainer/examples/basic.tscn
+++ b/addons/KOBUGE-games.CircularContainer/examples/basic.tscn
@@ -1,147 +1,102 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=4 format=3 uid="uid://df74xeai5mx2c"]
 
-[ext_resource path="res://addons/KOBUGE-games.CircularContainer/CircularContainer.gd" type="Script" id=1]
-[ext_resource path="res://addons/KOBUGE-games.CircularContainer/icon.png" type="Texture" id=2]
+[ext_resource type="Script" path="res://addons/KOBUGE-games.CircularContainer/CircularContainer.gd" id="1"]
 
-[sub_resource type="Animation" id=1]
+[sub_resource type="Animation" id="1"]
 tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("VBoxContainer/HBoxContainer/CircularContainer:animate/percent_visible")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 1 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [ 0.0, 1.0 ]
+"values": [0.0, 1.0]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("VBoxContainer/HBoxContainer/CircularContainer:arrange/start_angle")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 1 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [ 360.0, 0.0 ]
+"values": [360.0, 0.0]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_l553x"]
+_data = {
+"Example": SubResource("1")
 }
 
 [node name="Root" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Top" type="Panel" parent="VBoxContainer"]
-margin_right = 1024.0
-margin_bottom = 253.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 257.0
-margin_right = 1024.0
-margin_bottom = 342.0
+layout_mode = 2
 
 [node name="Left" type="Panel" parent="VBoxContainer/HBoxContainer"]
-margin_right = 465.0
-margin_bottom = 85.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="CircularContainer" type="Container" parent="VBoxContainer/HBoxContainer"]
-margin_left = 469.0
-margin_right = 554.845
-margin_bottom = 85.8449
-script = ExtResource( 1 )
-__meta__ = {
-"_editor_icon": ExtResource( 2 )
-}
-arrange/force_squares = true
-arrange/force_expand = true
-arrange/start_angle = 360.0
-arrange/start_empty = false
-arrange/allow_node2d = false
-animate/percent_visible = 0.0
-animate/all_at_once = false
+layout_mode = 2
+script = ExtResource("1")
 
 [node name="Button" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "1"
 
 [node name="Button1" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "2"
 
 [node name="Button2" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "3"
 
 [node name="Button3" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "4"
 
 [node name="Button4" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "5"
 
 [node name="Button5" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "6"
 
 [node name="Button6" type="Button" parent="VBoxContainer/HBoxContainer/CircularContainer"]
-margin_left = 42.9224
-margin_top = 42.9224
-margin_right = 62.9224
-margin_bottom = 62.9224
-rect_scale = Vector2( 0.01, 0.01 )
+layout_mode = 2
 text = "7"
 
 [node name="Right" type="Panel" parent="VBoxContainer/HBoxContainer"]
-margin_left = 558.0
-margin_right = 1024.0
-margin_bottom = 85.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Bottom" type="Panel" parent="VBoxContainer"]
-margin_top = 346.0
-margin_right = 1024.0
-margin_bottom = 600.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_l553x")
+}
 autoplay = "Example"
-anims/Example = SubResource( 1 )

--- a/addons/KOBUGE-games.CircularContainer/register.gd
+++ b/addons/KOBUGE-games.CircularContainer/register.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 func _enter_tree():

--- a/project.godot
+++ b/project.godot
@@ -6,17 +6,13 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[  ]
-_global_script_class_icons={
-
-}
+config_version=5
 
 [application]
 
 run/main_scene="res://addons/KOBUGE-games.CircularContainer/examples/basic.tscn"
+config/features=PackedStringArray("4.3")
 
 [editor_plugins]
 
-enabled=PoolStringArray( "KOBUGE-games.CircularContainer" )
+enabled=PackedStringArray("KOBUGE-games.CircularContainer")


### PR DESCRIPTION
This custom container is very useful for many use cases so _please consider_ these changes to allow compatibility with Godot 4.

These changes are the **minimal** required changes to the current code base to allow it to work on Godot **4.3**.

**Summary**
1. Removed the private setters and getters in `addons/KOBUGE-games.CircularContainer/CircularContainer.gd`.
2. Migrated the `_customAnimator`, `funcref`, to use a `Callable` implementation.
3. `deg2rad` now uses `deg_to_rad` and vice-versa.
4. `linear_interperlate` is now `lerp`.
5. Used Godot 4.3 to automatically update the `project.godot` and example scenes.